### PR TITLE
Add Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+import * as RDF from "rdf-js";
+
+export const defaultGraphInstance: RDF.DefaultGraph;
+export function namedNode(value: string): RDF.NamedNode;
+export function blankNode(value?: string): RDF.BlankNode;
+export function literal(value: string, languageOrDatatype?: string | RDF.NamedNode): RDF.Literal;
+export function variable(value: string): RDF.Variable;
+export function defaultGraph(): RDF.DefaultGraph;
+export function triple(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term): RDF.Quad;
+export function quad(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term, graph?: RDF.Term): RDF.Quad;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "bin": {
     "rdfjs-data-model-test": "./bin/test.js"
   },
+  "types": "./index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/rdfjs/data-model.git"


### PR DESCRIPTION
This PR adds the Typescript definitions (that previously existed at [@types/rdf-data-model](https://www.npmjs.com/package/@types/rdf-data-model)) to this repo and allows developers to use this package inside Typescript projects.

The reason for moving these typings in this repo is because this npm package has now been moved to a scoped name (@rdfjs/data-model), which makes it incompatible with the [DefinitelyTyped workflow](https://github.com/DefinitelyTyped/DefinitelyTyped) for adding package typings externally.

Note that these typings extend from [@types/rdf-js](https://www.npmjs.com/package/@types/rdf-js)